### PR TITLE
Fix incorrect classname in ParserConverter

### DIFF
--- a/src/Phergie/Irc/Event/ParserConverter.php
+++ b/src/Phergie/Irc/Event/ParserConverter.php
@@ -27,7 +27,7 @@ class ParserConverter
     public function convert(array $parserOutput)
     {
         if (!empty($parserOutput['targets'])) {
-           $event = new TargtedEvent();
+           $event = new TargetedEvent();
            $event->setTargets($parserOutput['targets']);
         } else {
             $event = new Event();


### PR DESCRIPTION
Classname is "TargetedEvent", not "TargtedEvent"
