### PR TITLE
Fix syntax error in EventInterface

### DIFF
--- a/src/Phergie/Irc/Event/EventInterface.php
+++ b/src/Phergie/Irc/Event/EventInterface.php
@@ -34,7 +34,7 @@ interface EventInterface
      *
      * @param \Phergie\ConnectionInterface $connection
      */
-    public function setConnection(\Phergie\ConnectionInterface);
+    public function setConnection(\Phergie\ConnectionInterface $connection);
 
     /**
      * Accessor method to retrieve connection instance


### PR DESCRIPTION
Argument name must be specified.
