### PR TITLE
Fix crash if event data has no params

### DIFF
--- a/src/ParserConverter.php
+++ b/src/ParserConverter.php
@@ -58,10 +58,12 @@ class ParserConverter implements ParserConverterInterface
             $event->setCode($data['code']);
         }
         $event->setMessage($data['message']);
-        if (isset($data['params']['all'])) {
-            unset($data['params']['all']);
+        if (isset($data['params'])) {
+            if (isset($data['params']['all'])) {
+                unset($data['params']['all']);
+            }
+            $event->setParams($data['params']);
         }
-        $event->setParams($data['params']);
         $event->setCommand($data['command']);
         return $event;
     }

--- a/tests/ParserConverterTest.php
+++ b/tests/ParserConverterTest.php
@@ -99,6 +99,17 @@ class ParserConverterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests convert() with a user event with no params.
+     */
+    public function testConvertWithUserEventWithoutParams()
+    {
+        $data = $this->userEvent;
+        unset($data['params']);
+        $event = $this->converter->convert($data);
+        $this->assertSame(array(), $event->getParams());
+    }
+
+    /**
      * Tests convert() with a user event without prefix data.
      */
     public function testConvertWithUserEventWithoutPrefix()


### PR DESCRIPTION
Outgoing events that can be called with no params (`ircQuit`, `ircAway` etc.) will currently cause a fatal error if called with no params. Changed the parser converter to not call `setParams()` if `$data['params']` does not exist.