### PR TITLE
Make user event nick comparisons case-insensitive

### DIFF
--- a/src/UserEvent.php
+++ b/src/UserEvent.php
@@ -160,8 +160,9 @@ class UserEvent extends Event implements UserEventInterface
      */
     public function getSource()
     {
-        $targets = $this->getTargets();
-        if (in_array($this->getConnection()->getNickname(), $targets)) {
+        $targets = array_map('strtolower', $this->getTargets());
+        $nick = strtolower($this->getConnection()->getNickname());
+        if (in_array($nick, $targets)) {
             return $this->getNick();
         }
         return reset($targets);

--- a/tests/UserEventTest.php
+++ b/tests/UserEventTest.php
@@ -136,6 +136,7 @@ class UserEventTest extends EventTest
         $data = array();
         $data[] = array('#channel', '#channel');
         $data[] = array('bot', 'user');
+        $data[] = array('Bot', 'user');
         return $data;
     }
 


### PR DESCRIPTION
Currently, if a user sends a message (e.g. `PRIVMSG`) to the bot and specifies the bot's nick using a case that is not consistent with the nick specified in the bot's connection configuration, the check for user-sent events that is performed in `UserEvent->getSource()` fails and the bot essentially attempts to message itself because the first event argument / target is the bot's nick.

While the IRC protocol itself doesn't seem specific about the case sensitivity of nicks, a number of servers do not treat them in a case-sensitive fashion.

This PR modifies the check to determine the event source such that it treats the specified bot nick in a case-insensitive fashion so that the bot can properly determine the user who sent the event.

Hat tip to @frozen-solid for uncovering this bug.