### PR TITLE
Drop php 5 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
+  - 7
   - hhvm
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "source": "https://github.com/phergie/phergie-irc-event"
     },
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.6.0",
         "phergie/phergie-irc-connection": "2.*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "dca4d20acf3e7b58258e709c4564646e",
+    "hash": "d207dd8b03d0d254b1719bb7bd22e83c",
+    "content-hash": "43c7491f81efa3f99e34d95dc4b76f7f",
     "packages": [
         {
             "name": "phergie/phergie-irc-connection",
@@ -866,7 +867,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=5.6.0"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
updated the php minimum version and updated the `.travis.yml` file.  

I added php 7 to the travis file even though it hadn't been there before.

resolves #16 
